### PR TITLE
Fix nginx access regex to accept punctuation in tracecontext options

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -98,7 +98,7 @@
   # The default format ends with ..."(?<agent>[^\"]*)")?$/ . This regex is
   # the same as the default up until the end, at which point, before the $,
   # there is an optional group to look for tracecontext= and parse the traceId.
-  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^/\"]*)[^".]*")?$/ 
+  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^/\"]*)[^\"]*")?$/
   time_format %d/%b/%Y:%H:%M:%S %z 
   path /var/log/nginx/access.log
   pos_file /var/tmp/fluentd.nginx-access.pos


### PR DESCRIPTION
R: @apolito

Accidentally left this improvement out of the original PR. Sorry!