### PR TITLE
Use HTTP 1.1 to connect to the application servers

### DIFF
--- a/nginx_proxy/proxy_pass.inc
+++ b/nginx_proxy/proxy_pass.inc
@@ -1,6 +1,8 @@
 # configuration settings for proxy_pass to main app
 proxy_pass http://app_server;
 proxy_redirect off;
+proxy_http_version 1.1;
+proxy_set_header Connection "";
 proxy_set_header Host $host;
 proxy_set_header X-Real-IP $remote_addr;
 proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This more than doubles performance during a standalone test of wrk against an
nginx proxying to a Go hello world application running on the same server.

Although this doesn't have such a drastic effect on performance due to slower links in the chain today, this eradicates load and bottlenecks for future versions.