### PR TITLE
Memcache proxy: read all the input buffer, increase buffer size, add tests for max me…

### DIFF
--- a/memcache_proxy/dtog.go
+++ b/memcache_proxy/dtog.go
@@ -384,7 +384,7 @@ func unpackFirstStorageCmdArgs(args ...[]byte) (key []byte, flags uint32,
 	// based on this number and this will only fail once we actually hit
 	// App Engine Memcache.
 	if bytes > maxMemcacheValueSize {
-		err = clientError{"bad command line format",
+		err = clientError{"MEMCACHED_E2BIG",
 			fmt.Sprintf("Value size should not be greater than %d, but got %d.",
 				maxMemcacheValueSize, bytes)}
 		return

--- a/memcache_proxy/dtog.go
+++ b/memcache_proxy/dtog.go
@@ -33,12 +33,6 @@ import (
 	pb "google.golang.org/appengine/notreallyinternal/memcache"
 )
 
-const (
-	// Max App Engine Memcache value size (10^6 bytes).
-	// https://cloud.google.com/appengine/docs/python/memcache/
-	maxMemcacheValueSize = 1000000
-)
-
 // Proxy is the proxy server running on some host:port Address.
 type Proxy struct {
 	BindingAddr string
@@ -379,16 +373,6 @@ func unpackFirstStorageCmdArgs(args ...[]byte) (key []byte, flags uint32,
 		return
 	}
 	bytes = uint32(bytesUpc)
-	// Make sure we only accept up to 1000000 bytes to read (max value size
-	// for App Engine cache). Other parts of the code will allocate memory
-	// based on this number and this will only fail once we actually hit
-	// App Engine Memcache.
-	if bytes > maxMemcacheValueSize {
-		err = clientError{"MEMCACHED_E2BIG",
-			fmt.Sprintf("Value size should not be greater than %d, but got %d.",
-				maxMemcacheValueSize, bytes)}
-		return
-	}
 	return
 }
 

--- a/memcache_proxy/dtog_test.go
+++ b/memcache_proxy/dtog_test.go
@@ -50,7 +50,6 @@ func generateString(n int, r rune) string {
 }
 
 var maxMemcachePayloadValue = generateString(1000000, 'a')
-var overMaxMemcachePayloadValue = generateString(1000001, 'a')
 
 // Read lines from connection, folding in errors with responses and
 // returning special markers for timeout and EOF.
@@ -445,14 +444,6 @@ func TestAll(t *testing.T) {
 			}),
 			"set aMaxPayloadKey 111 3600 " + strconv.Itoa(len(maxMemcachePayloadValue)) + "\r\n" + maxMemcachePayloadValue + "\r\n",
 			[]string{},
-		},
-		{"set request over max memcache size ",
-			setNeverCalled,
-			"set aOverMaxPayloadKey 111 3600 " + strconv.Itoa(len(overMaxMemcachePayloadValue)) + "\r\n" + overMaxMemcachePayloadValue + "\r\n",
-			[]string{
-				"CLIENT_ERROR MEMCACHED_E2BIG\r\n",
-				timeoutMarker,
-			},
 		},
 		{"set request with whitespace",
 			fakeSetContext(t, func(req *pb.MemcacheSetRequest, _ *pb.MemcacheSetResponse) {

--- a/memcache_proxy/dtog_test.go
+++ b/memcache_proxy/dtog_test.go
@@ -12,7 +12,7 @@ You may obtain a copy of the License at
  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  See the License for the specific language governing permissions and
  limitations under the License.
- */
+*/
 
 package dtog
 
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +40,17 @@ const (
 	// Binding Addr for testing purposes.
 	bindingAddr = "localhost:11211"
 )
+
+func generateString(n int, r rune) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = r
+	}
+	return string(b)
+}
+
+var maxMemcachePayloadValue = generateString(1000000, 'a')
+var overMaxMemcachePayloadValue = generateString(1000001, 'a')
 
 // Read lines from connection, folding in errors with responses and
 // returning special markers for timeout and EOF.
@@ -408,6 +420,39 @@ func TestAll(t *testing.T) {
 			}),
 			"set aKey 111 3600 10\r\nsome value\r\n",
 			[]string{},
+		},
+		{"set request max memcache size ",
+			fakeSetContext(t, func(req *pb.MemcacheSetRequest, _ *pb.MemcacheSetResponse) {
+				serviceCalled = true
+				// Test request.
+				want := &pb.MemcacheSetRequest{
+					NameSpace: proto.String(""),
+					Item: []*pb.MemcacheSetRequest_Item{
+						&pb.MemcacheSetRequest_Item{
+							Key:            []byte("aMaxPayloadKey"),
+							Value:          []byte(maxMemcachePayloadValue),
+							Flags:          proto.Uint32(111),
+							SetPolicy:      pb.MemcacheSetRequest_SET.Enum(),
+							ExpirationTime: proto.Uint32(3600),
+						},
+					},
+				}
+				if !proto.Equal(req, want) {
+					t.Errorf("got  <%s>\nwant <%s>",
+						proto.MarshalTextString(req),
+						proto.MarshalTextString(want))
+				}
+			}),
+			"set aMaxPayloadKey 111 3600 " + strconv.Itoa(len(maxMemcachePayloadValue)) + "\r\n" + maxMemcachePayloadValue + "\r\n",
+			[]string{},
+		},
+		{"set request over max memcache size ",
+			setNeverCalled,
+			"set aOverMaxPayloadKey 111 3600 " + strconv.Itoa(len(overMaxMemcachePayloadValue)) + "\r\n" + overMaxMemcachePayloadValue + "\r\n",
+			[]string{
+				"CLIENT_ERROR bad command line format\r\n",
+				timeoutMarker,
+			},
 		},
 		{"set request with whitespace",
 			fakeSetContext(t, func(req *pb.MemcacheSetRequest, _ *pb.MemcacheSetResponse) {

--- a/memcache_proxy/dtog_test.go
+++ b/memcache_proxy/dtog_test.go
@@ -450,7 +450,7 @@ func TestAll(t *testing.T) {
 			setNeverCalled,
 			"set aOverMaxPayloadKey 111 3600 " + strconv.Itoa(len(overMaxMemcachePayloadValue)) + "\r\n" + overMaxMemcachePayloadValue + "\r\n",
 			[]string{
-				"CLIENT_ERROR bad command line format\r\n",
+				"CLIENT_ERROR MEMCACHED_E2BIG\r\n",
 				timeoutMarker,
 			},
 		},


### PR DESCRIPTION
This change:
- Makes sure that we read all the input by using io.ReadFull() - this fixes the issue of not reading beyond the default buffer size (4096)
- Increases buffer size to help reading larger memcache values
- Add unit tests, incl. max memcache key size