### PR TITLE
Expose an HTTP socket to receive app container logs

### DIFF
--- a/fluentd_logger/Dockerfile
+++ b/fluentd_logger/Dockerfile
@@ -17,6 +17,8 @@ ADD managed_vms.conf /etc/google-fluentd/google-fluentd.conf
 
 CMD []
 
+EXPOSE 24224
+
 ENTRYPOINT ["/opt/google-fluentd/embedded/bin/ruby", \
             "/usr/sbin/google-fluentd", \
             "--log", "/var/log/google-fluentd/google-fluentd.log"]

--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -1,4 +1,10 @@
 <source>
+  type forward
+  port 24224
+  bind 0.0.0.0
+</source>
+
+<source>
   type tail
   format none
   path /var/log/app_engine/app/app*.log

--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -4,6 +4,13 @@
   bind 0.0.0.0
 </source>
 
+# For app container logs (stdout/stderr) coming in on the HTTP port,
+# rewrite the tag by looking at the source field.
+<match app-container>
+  @type rewrite_tag_filter
+  rewriterule1 source ^(\w+) $1
+</match>
+
 <source>
   type tail
   format none


### PR DESCRIPTION
R: @jonparrott 

This opens port 24224 and listens on it for app container logs. Logs that come in with the tag "app-container" are rewritten so that the tag is equal to the source stream (stdout or stderr) to emulate existing behavior.

Changes on the VM agent are required to use this functionality. The old logging functionality is intact so that this fluentd image will be backwards-compatible with older VM agents.