### PR TITLE
memcache_proxy: return "App Engine" for "version"

### DIFF
--- a/memcache_proxy/dtog.go
+++ b/memcache_proxy/dtog.go
@@ -246,6 +246,8 @@ func (s *streams) demux(command string, args ...[]byte) error {
 		return s.flush(args...)
 	case "stats":
 		return s.stats()
+	case "version":
+		return s.version()
 	default:
 		return serverError{fmt.Errorf("unimplemented command")}
 	}
@@ -672,5 +674,12 @@ func (s *streams) stats() error {
 		s.out.printfLn("STAT oldest_item_age %d", res.Stats.GetOldestItemAge())
 	}
 	s.out.printLn([]byte("END"))
+	return nil
+}
+
+// version handles the "version" command on the memcached socket and
+// returns "not implemented" as this proxy is not versioned.
+func (s *streams) version() error {
+	s.out.printfLn("VERSION not implemented")
 	return nil
 }

--- a/memcache_proxy/dtog.go
+++ b/memcache_proxy/dtog.go
@@ -678,8 +678,8 @@ func (s *streams) stats() error {
 }
 
 // version handles the "version" command on the memcached socket and
-// returns "not implemented" as this proxy is not versioned.
+// returns "App Engine" as this proxy is not versioned.
 func (s *streams) version() error {
-	s.out.printfLn("VERSION not implemented")
+	s.out.printfLn("VERSION App Engine")
 	return nil
 }

--- a/memcache_proxy/dtog_test.go
+++ b/memcache_proxy/dtog_test.go
@@ -787,7 +787,7 @@ func TestAll(t *testing.T) {
 			nil,
 			"version\r\n",
 			[]string{
-				"VERSION not implemented\r\n",
+				"VERSION App Engine\r\n",
 				timeoutMarker,
 			},
 		},

--- a/memcache_proxy/dtog_test.go
+++ b/memcache_proxy/dtog_test.go
@@ -783,6 +783,14 @@ func TestAll(t *testing.T) {
 				timeoutMarker,
 			},
 		},
+		{"version request",
+			nil,
+			"version\r\n",
+			[]string{
+				"VERSION not implemented\r\n",
+				timeoutMarker,
+			},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Some clients use `Memcached::getVersion` to determine if the server is running and the connection is working.  The current implementation [throws an error](https://github.com/GoogleCloudPlatform/appengine-sidecars-docker/blob/master/memcache_proxy/dtog.go#L250), which results in clients making the mistaken assumption the server is not responding.

This PR adds support for the [version](https://github.com/memcached/memcached/blob/1.2.4/doc/protocol.txt#L422) protocol command, but returns "not implemented". This allows the client to verify the connection is successful, but does not return any actual versioning information since we do not actually have a version number.

**Usage**
```
$ telnet <proxy-ip> <proxy-host>
Trying <proxy-ip>...
Connected to <proxy-ip>.
Escape character is '^]'.
version
VERSION not implemented
```

**Alternatives**
 -`VERSION appengine_proxy.v1`
 -`VERSION 1`

Using "not implemented" is the safest/least complicated solution, but either of these alternatives would also be okay.