### PR TITLE
Revert "Expose an HTTP socket to receive app container logs"

### DIFF
--- a/fluentd_logger/Dockerfile
+++ b/fluentd_logger/Dockerfile
@@ -17,8 +17,6 @@ ADD managed_vms.conf /etc/google-fluentd/google-fluentd.conf
 
 CMD []
 
-EXPOSE 24224
-
 ENTRYPOINT ["/opt/google-fluentd/embedded/bin/ruby", \
             "/usr/sbin/google-fluentd", \
             "--log", "/var/log/google-fluentd/google-fluentd.log"]

--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -1,17 +1,4 @@
 <source>
-  type forward
-  port 24224
-  bind 0.0.0.0
-</source>
-
-# For app container logs (stdout/stderr) coming in on the HTTP port,
-# rewrite the tag by looking at the source field.
-<match app-container>
-  @type rewrite_tag_filter
-  rewriterule1 source ^(\w+) $1
-</match>
-
-<source>
   type tail
   format none
   path /var/log/app_engine/app/app*.log


### PR DESCRIPTION
Reverts GoogleCloudPlatform/appengine-sidecars-docker#15

Due to possible stability regressions from routing Docker logs directly to fluentd, we're rolling this feature back. It's not important that this rollback be picked up in a timely fashion because the business logic is elsewhere; this is just cleanup of a now unexposed feature.

R: @Cynocracy