### PR TITLE
Add regex to parse time from the $msec directive of nginx.

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -101,8 +101,9 @@
   tag syslog
 </source>
 
-# Parse nginx request (access) logs, which may inc. a custom HTTP header suffix:
+# Parse nginx request (access) logs, which may inc. multiple custom suffixes:
 #   tracecontext="(hexadecimal traceId)/options"
+#   timestampSeconds="(epoch seconds, floating point)"
 # where the / and the options are themselves optional. Instead of using the
 # default "format nginx" directive, this uses a custom regex to capture both
 # standard and modified nginx logs and add traceId if one is found.

--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -110,8 +110,11 @@
   type tail
   # The default format ends with ..."(?<agent>[^\"]*)")?$/ . This regex is
   # the same as the default up until the end, at which point, before the $,
-  # there is an optional group to look for tracecontext= and parse the traceId.
-  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^/\"]*)[^\"]*")?$/
+  # there are optional groups for the tracecontext and the time in seconds.
+  # The timeSeconds and timeNanos are used preferentially by cloud logging
+  # in place of the standard time capture, which grants us the ability to do
+  # sub-second granular logs.
+  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^/\"]*)[^\"]*")?(?: timestampSeconds="(?<timestampSeconds>[^\.\"]*)\.(?<timestampNanos>[^\"]*)")?$/
   time_format %d/%b/%Y:%H:%M:%S %z 
   path /var/log/nginx/access.log
   pos_file /var/tmp/fluentd.nginx-access.pos


### PR DESCRIPTION
R: @andrewsg 

This allows us to send sub-second granular logs, despite the limitations of the version of fluentd currently used by google-fluentd.

Logs before and after the change to nginx config pushed out with the vm image need to be parseable.

Sample log before change:
172.17.0.1 - - [23/Aug/2016:01:57:20 +0000] "GET /_ah/health HTTP/1.1" 200 2 "-" "curl/7.26.0" tracecontext="-"

Sample log after change:
172.17.0.1 - - [23/Aug/2016:01:57:20 +0000] "GET /_ah/health HTTP/1.1" 200 2 "-" "curl/7.26.0" tracecontext="-" timestampSeconds="1471917440.683000000"