### PR TITLE
Update fluentd config for nginx.error.

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -120,8 +120,8 @@
   path /var/log/nginx/error.log
 
   format multiline
-  format_firstline /^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\w+\] (?<pid>\d+).(?<tid>\d+): /
-  format1 /^(?<time>\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) \[(?<log_level>\w+)\] (?<pid>\d+).(?<tid>\d+): (?<message>.*)/
+  format_firstline /^\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2} \[\w+\] \d+.\d+: /
+  format1 /^(?<time>\d{4}/\d{2}/\d{2} \d{2}:\d{2}:\d{2}) (?<message>.*)/
   multiline_flush_interval 3s
   tag nginx.error
 </source>


### PR DESCRIPTION
R: @andrewsg 

Loglevel, pid, and tid were previously hidden in the cloud logging UI, this should surface them in a more user-friendly way for now (by simply including them in the message).

As nginx uses non-standard log levels, we shouldn't just output it as (?<severity>), which would normally be the right and proper way to go about it.