### PR TITLE
Filter health check requests into a separate tag.

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -110,8 +110,15 @@
   pos_file /var/tmp/fluentd.nginx-access.pos
   read_from_head true
   rotate_wait 10s
-  tag nginx.request
+  tag nginx.unmatched
 </source>
+
+# Sort nginx logs into reasonable buckets.
+<match nginx.unmatched>
+  type rewrite_tag_filter
+  rewriterule1 path /_ah/health nginx.health_check
+  rewriterule2 path .* nginx.request
+</match>
 
 # Parse nginx error logs in the common format
 # see http://docs.fluentd.org/articles/common-log-formats


### PR DESCRIPTION
R: @andrewsg 

This allows users to distinguish between health checks and actual accesses.