### PR TITLE
Rename syslog -> vm.syslog as part of log tag cleanup.

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -85,7 +85,7 @@
   pos_file /var/tmp/fluentd.syslog.pos
   read_from_head true
   rotate_wait 10s
-  tag syslog
+  tag vm.syslog
 </source>
 
 # Parse nginx request (access) logs, which may inc. multiple custom suffixes:


### PR DESCRIPTION
R: @andrewsg 