### PR TITLE
Make fluentd accept nginx access logs with unrecognized additional data at the end of a line

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -104,7 +104,7 @@
   # The timeSeconds and timeNanos are used preferentially by cloud logging
   # in place of the standard time capture, which grants us the ability to do
   # sub-second granular logs.
-  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^/\"]*)[^\"]*")?(?: timestampSeconds="(?<timestampSeconds>[^\.\"]*)\.(?<timestampNanos>[^\"]*)")?(?: latencySeconds="(?<latencySeconds>[^\"]*)")?$/
+  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +\S*)?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^/\"]*)[^\"]*")?(?: timestampSeconds="(?<timestampSeconds>[^\.\"]*)\.(?<timestampNanos>[^\"]*)")?(?: latencySeconds="(?<latencySeconds>[^\"]*)")?.*$/
   time_format %d/%b/%Y:%H:%M:%S %z 
   path /var/log/nginx/access.log
   pos_file /var/tmp/fluentd.nginx-access.pos


### PR DESCRIPTION
+R @rdcastro 

This will allow us to add additional data like x-forwarded-for to the nginx config without having to update fluentd in lockstep (safer rollouts).