### PR TITLE
Revert "Add plugin to detect exceptions in stdout/stderr and log them in one log entry"

### DIFF
--- a/fluentd_logger/Dockerfile
+++ b/fluentd_logger/Dockerfile
@@ -8,8 +8,6 @@ RUN apt-get -q update && \
 
 RUN curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | DO_NOT_INSTALL_CATCH_ALL_CONFIG=1 bash
 
-RUN /usr/sbin/google-fluentd-gem install --conservative fluent-plugin-detect-exceptions:0.0.4
-
 # Add cloud agent driver
 ADD out_from_docker.rb /etc/google-fluentd/plugin/out_from_docker.rb
 

--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -186,18 +186,8 @@
 # Docker container logs go through the from_docker container
 <match docker.var.log.saved_docker.*.*.log>
   type from_docker
-  stdout_tag raw.stdout
-  stderr_tag raw.stderr
-</match>
-
-# Detect exceptions from stdout and stderr of Docker containers.
-<match raw.**>
-  type detect_exceptions
-  remove_tag_prefix raw
-  message message
-  multiline_flush_interval 5
-  max_bytes 50000
-  max_lines 500
+  stdout_tag stdout
+  stderr_tag stderr
 </match>
 
 <match **>


### PR DESCRIPTION
Reverts GoogleCloudPlatform/appengine-sidecars-docker#41

Need to revert this as it's incompatible with Fluentd 0.14.x and causing a worker process reboot loop:

/opt/google-fluentd/embedded/lib/ruby/site_ruby/2.1.0/rubygems/specification.rb:2112:in `raise_if_conflicts': Unable to activate fluent-plugin-detect-exceptions-0.0.4, because fluentd-0.14.8 conflicts with fluentd (<= 0.13, ~> 0.10) (Gem::ConflictError)

cc: @thomasschickinger 