### PR TITLE
Reenable detect exception plugin and switch version to 0.0.5.

### DIFF
--- a/fluentd_logger/Dockerfile
+++ b/fluentd_logger/Dockerfile
@@ -8,6 +8,8 @@ RUN apt-get -q update && \
 
 RUN curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | DO_NOT_INSTALL_CATCH_ALL_CONFIG=1 bash
 
+RUN /usr/sbin/google-fluentd-gem install --conservative fluent-plugin-detect-exceptions:0.0.5
+
 # Add cloud agent driver
 ADD out_from_docker.rb /etc/google-fluentd/plugin/out_from_docker.rb
 

--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -186,8 +186,18 @@
 # Docker container logs go through the from_docker container
 <match docker.var.log.saved_docker.*.*.log>
   type from_docker
-  stdout_tag stdout
-  stderr_tag stderr
+  stdout_tag raw.stdout
+  stderr_tag raw.stderr
+</match>
+
+# Detect exceptions from stdout and stderr of Docker containers.
+<match raw.**>
+  type detect_exceptions
+  remove_tag_prefix raw
+  message message
+  multiline_flush_interval 5
+  max_bytes 50000
+  max_lines 500
 </match>
 
 <match **>


### PR DESCRIPTION
v0.0.5 of the plugin has removed the upper bound on the fluentd version and is compatible with every 0.1x version of fluentd.