### PR TITLE
App shutdown logs as a source in fluentd config

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -51,6 +51,16 @@
 <source>
   type tail
   format none
+  path /app/log/app_engine/app.shutdown.*.final
+  pos_file /var/tmp/fluentd.shutdown.pos
+  read_from_head true
+  rotate_wait 10s
+  tag app.shutdown
+</source>
+
+<source>
+  type tail
+  format none
   path /var/log/app_engine/app/custom_logs/*.log
   pos_file /var/tmp/fluentd.custom_logs.pos
   read_from_head true

--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -51,7 +51,7 @@
 <source>
   type tail
   format none
-  path /app/log/app_engine/app.shutdown.*.final
+  path /var/log/app_engine/app.shutdown.*.final
   pos_file /var/tmp/fluentd.shutdown.pos
   read_from_head true
   rotate_wait 10s


### PR DESCRIPTION
The app container dumps some logs that need to be reported to the correct log stream.

+R @andrewsg 