### PR TITLE
#63701884: Increase fluentd num threads to 8

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -196,6 +196,7 @@
   flush_interval 5s
   # Never wait longer than 5 minutes between retries
   max_retry_wait 300
+  num_threads 8
   disable_retry_limit
   # Send these fields as labels instead of in the struct_payload
   label_map {


### PR DESCRIPTION
This change increases the number of threads available to fluentd to 8 per https://docs.fluentd.org/v0.12/articles/out_file. 

Using more than 1 thread is a recommendation when the destination of the logs is remote - as is Flex's scenario where we upload our logs to a service.

More details in (e.g.):
https://blog.treasuredata.com/blog/2015/08/18/5-tips-to-optimize-fluentd-performance/ 