### PR TITLE
Clean up httpRequest proto

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -197,7 +197,16 @@
 <filter nginx.{health_check,request}>
   type record_transformer
   <record>
-    httpRequest {"requestMethod": "${record[\"method\"]}", "referer": "${record[\"referer\"]}", "remoteIp": "${record[\"remote\"]}", "userAgent": "${record[\"agent\"]}", "requestUrl": "${record[\"path\"]}", "responseSize": "${record[\"size\"]}", "status": "${record[\"code\"]}", "latency": "${record[\"latencySeconds\"]}s", "appLatency": "${record[\"appLatencySeconds\"}s"}
+    httpRequest {
+      "requestMethod": "${record[\"method\"]}",
+      "referer": "${record[\"referer\"]}",
+      "remoteIp": "${record[\"remote\"]}",
+      "userAgent": "${record[\"agent\"]}",
+      "requestUrl": "${record[\"path\"]}",
+      "responseSize": "${record[\"size\"]}",
+      "status": "${record[\"code\"]}",
+      "latency": "${record[\"latencySeconds\"]}s"
+    }
     trace "${record[\"traceId\"]}"
   </record>
   renew_record true


### PR DESCRIPTION
1. Make it not all on one line.
2. Remove appLatencySeconds, since httpRequest is turned into an
HttpRequest proto, which does not have an app_latency_seconds field.
(appLatencySeconds is included as a generic key in the JsonPayload
object due to its intry in the the "keep_keys" tag.)