### PR TITLE
Fix IAP watcher

### DIFF
--- a/iap_watcher/Dockerfile
+++ b/iap_watcher/Dockerfile
@@ -5,7 +5,7 @@ FROM gcr.io/google_appengine/debian8
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends python python-pip cron && \
+    apt-get install -y --no-install-recommends python python-pip cron curl && \
     apt-get clean
 RUN pip install google-compute-engine
 
@@ -15,9 +15,8 @@ VOLUME /iap_watcher
 RUN mkdir -p /home/vmagent/iap_watcher
 WORKDIR /home/vmagent/iap_watcher
 ADD iap_watcher.py .
-ENTRYPOINT ["./iap_watcher.py", "--iap_metadata_key=AEF_IAP_state", "--output_state_file=/iap_watcher/iap_state"]
+ENTRYPOINT ["./iap_watcher.py", "--iap_metadata_key=AEF_IAP_state", "--output_state_file=/iap_watcher/iap_state", "--fetch_keys=True"]
 
-RUN curl "https://www.gstatic.com/iap/verify/public_key-jwk" > /iap_watcher/iap_verify_keys.txt
 RUN echo "15 */1 * * * curl 'https://www.gstatic.com/iap/verify/public_key-jwk' > /iap_watcher/iap_verify_keys.txt" >> .tmp_cron
 RUN crontab .tmp_cron
 RUN rm .tmp_cron

--- a/iap_watcher/Dockerfile
+++ b/iap_watcher/Dockerfile
@@ -5,7 +5,7 @@ FROM gcr.io/google_appengine/debian8
 
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends python python-pip cron curl && \
+    apt-get install -y --no-install-recommends cron curl python python-pip && \
     apt-get clean
 RUN pip install google-compute-engine
 
@@ -15,8 +15,14 @@ VOLUME /iap_watcher
 RUN mkdir -p /home/vmagent/iap_watcher
 WORKDIR /home/vmagent/iap_watcher
 ADD iap_watcher.py .
-ENTRYPOINT ["./iap_watcher.py", "--iap_metadata_key=AEF_IAP_state", "--output_state_file=/iap_watcher/iap_state", "--fetch_keys=True"]
+ENV OUTPUT_KEY_FILE /iap_watcher/iap_verify_keys.txt
+ENTRYPOINT [ \
+    "./iap_watcher.py", \
+    "--iap_metadata_key=AEF_IAP_state", \
+    "--output_state_file=/iap_watcher/iap_state", \
+    "--fetch_keys=True", \
+    "--output_key_file=${OUTPUT_KEY_FILE}"]
 
-RUN echo "15 */1 * * * curl 'https://www.gstatic.com/iap/verify/public_key-jwk' > /iap_watcher/iap_verify_keys.txt" >> .tmp_cron
+RUN echo "15 */1 * * * curl 'https://www.gstatic.com/iap/verify/public_key-jwk' > ${OUTPUT_KEY_FILE}" >> .tmp_cron
 RUN crontab .tmp_cron
 RUN rm .tmp_cron

--- a/iap_watcher/iap_watcher.py
+++ b/iap_watcher/iap_watcher.py
@@ -44,7 +44,7 @@ def UpdateStateFileFromMetadata(value, output_file):
     logging.info('Retry due to empty value.')
 
 
-def Main(argv, watcher=None, loop_watcher=True, fetch_keys=False):
+def Main(argv, watcher=None, loop_watcher=True):
   """Runs the watcher.
 
   Args:
@@ -55,8 +55,9 @@ def Main(argv, watcher=None, loop_watcher=True, fetch_keys=False):
   logger = logging.getLogger()
   logger.setLevel(logging.INFO)
 
-  # This ensures we have fresh keys at container start.
-  if (fetch_keys):
+  # This ensures we have fresh keys at container start. Doing it here because
+  # Docker doesn't support multiple CMD/ENTRYPOINT statements in Dockerfiles.
+  if (argv.fetch_keys):
     os.system('curl "https://www.gstatic.com/iap/verify/public_key-jwk" > '
               '/iap_watcher/iap_verify_keys.txt')
 
@@ -89,5 +90,8 @@ if __name__ == '__main__':
   parser.add_argument('--polling_interval', type=int, required=False,
                       help='Seconds between metadata fetch attempts.',
                       default=DEFAULT_POLLING_INTERVAL_SEC)
+  parser.add_argument('--fetch_keys', type=bool, required=False,
+                      help='Whether to fetch the keys at start up',
+                      default=False)
   args = parser.parse_args()
   Main(args)

--- a/iap_watcher/iap_watcher.py
+++ b/iap_watcher/iap_watcher.py
@@ -44,7 +44,7 @@ def UpdateStateFileFromMetadata(value, output_file):
     logging.info('Retry due to empty value.')
 
 
-def Main(argv, watcher=None, loop_watcher=True):
+def Main(argv, watcher=None, loop_watcher=True, os_system=os.system):
   """Runs the watcher.
 
   Args:
@@ -58,7 +58,7 @@ def Main(argv, watcher=None, loop_watcher=True):
   # This ensures we have fresh keys at container start. Doing it here because
   # Docker doesn't support multiple CMD/ENTRYPOINT statements in Dockerfiles.
   if (argv.fetch_keys):
-    os.system('curl "https://www.gstatic.com/iap/verify/public_key-jwk" > '
+    os_system('curl "https://www.gstatic.com/iap/verify/public_key-jwk" > '
               + argv.output_key_file)
 
   polling_interval = argv.polling_interval

--- a/iap_watcher/iap_watcher.py
+++ b/iap_watcher/iap_watcher.py
@@ -44,7 +44,7 @@ def UpdateStateFileFromMetadata(value, output_file):
     logging.info('Retry due to empty value.')
 
 
-def Main(argv, watcher=None, loop_watcher=True):
+def Main(argv, watcher=None, loop_watcher=True, fetch_keys=False):
   """Runs the watcher.
 
   Args:
@@ -54,6 +54,11 @@ def Main(argv, watcher=None, loop_watcher=True):
   """
   logger = logging.getLogger()
   logger.setLevel(logging.INFO)
+
+  # This ensures we have fresh keys at container start.
+  if (fetch_keys):
+    os.system('curl "https://www.gstatic.com/iap/verify/public_key-jwk" > '
+              '/iap_watcher/iap_verify_keys.txt')
 
   polling_interval = argv.polling_interval
 

--- a/iap_watcher/iap_watcher.py
+++ b/iap_watcher/iap_watcher.py
@@ -59,7 +59,7 @@ def Main(argv, watcher=None, loop_watcher=True):
   # Docker doesn't support multiple CMD/ENTRYPOINT statements in Dockerfiles.
   if (argv.fetch_keys):
     os.system('curl "https://www.gstatic.com/iap/verify/public_key-jwk" > '
-              '/iap_watcher/iap_verify_keys.txt')
+              + argv.output_key_file)
 
   polling_interval = argv.polling_interval
 
@@ -93,5 +93,7 @@ if __name__ == '__main__':
   parser.add_argument('--fetch_keys', type=bool, required=False,
                       help='Whether to fetch the keys at start up',
                       default=False)
+  parser.add_argument('--output_key_file', type=str, required=False,
+                      help='Where to output the state object to.')
   args = parser.parse_args()
   Main(args)

--- a/iap_watcher/iap_watcher_test.py
+++ b/iap_watcher/iap_watcher_test.py
@@ -121,10 +121,8 @@ class TestIapVerifier(unittest.TestCase):
     state_path = '%s/tmp' % self.pathname_
     key_path = '%s/keys' % self.pathname_
     self.metadata_watcher_.SetGetMetadataResult('{"enabled": true}')
-    class OsMock:
-      def system(self, cmd):
-        self.cmd = cmd
-    os_mock = OsMock()
+    def mock_os_system(command):
+      self.cmd = command
     iap_watcher.Main(Object({
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': state_path,
@@ -134,9 +132,9 @@ class TestIapVerifier(unittest.TestCase):
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False,
-      os_system=os_mock.system)
+      os_system=mock_os_system)
     self.assertEqual(
-        os_mock.cmd,
+        self.cmd,
         'curl "https://www.gstatic.com/iap/verify/public_key-jwk" > '
             + key_path)
 

--- a/iap_watcher/iap_watcher_test.py
+++ b/iap_watcher/iap_watcher_test.py
@@ -34,6 +34,7 @@ class TestIapVerifier(unittest.TestCase):
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': path,
         'polling_interval': 1,
+        'fetch_keys': False,
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False)
@@ -47,6 +48,7 @@ class TestIapVerifier(unittest.TestCase):
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': path,
         'polling_interval': 1,
+        'fetch_keys': False,
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False)
@@ -60,6 +62,7 @@ class TestIapVerifier(unittest.TestCase):
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': path,
         'polling_interval': 1,
+        'fetch_keys': False,
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False)
@@ -70,6 +73,7 @@ class TestIapVerifier(unittest.TestCase):
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': path,
         'polling_interval': 1,
+        'fetch_keys': False,
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False)
@@ -83,6 +87,7 @@ class TestIapVerifier(unittest.TestCase):
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': path,
         'polling_interval': 1,
+        'fetch_keys': False,
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False)
@@ -93,6 +98,7 @@ class TestIapVerifier(unittest.TestCase):
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': path,
         'polling_interval': 1,
+        'fetch_keys': False,
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False)
@@ -103,6 +109,7 @@ class TestIapVerifier(unittest.TestCase):
         'iap_metadata_key': 'AEF_IAP_state',
         'output_state_file': path,
         'polling_interval': 1,
+        'fetch_keys': False,
       }),
       watcher=self.metadata_watcher_,
       loop_watcher=False)


### PR DESCRIPTION
1. Install curl so that keys can actually be fetched
2. Move initial key fetch from build time to container start time

Testing:
 - Unit tests pass.
 - Built and started container locally; initial key fetch occurred as expected.