### PR TITLE
Update fluent-plugin-google-cloud to 0.6.12

### DIFF
--- a/fluentd_logger/Dockerfile
+++ b/fluentd_logger/Dockerfile
@@ -8,7 +8,7 @@ RUN apt-get -q update && \
 
 RUN curl -s https://storage.googleapis.com/signals-agents/logging/google-fluentd-install.sh | DO_NOT_INSTALL_CATCH_ALL_CONFIG=1 bash
 
-RUN /usr/sbin/google-fluentd-gem install --conservative fluent-plugin-google-cloud:0.6.8
+RUN /usr/sbin/google-fluentd-gem install --conservative fluent-plugin-google-cloud:0.6.12
 RUN /usr/sbin/google-fluentd-gem install --conservative fluent-plugin-detect-exceptions:0.0.8
 
 # Add cloud agent driver


### PR DESCRIPTION
0.6.8 may have been impacted by a memory leak issue: see https://github.com/GoogleCloudPlatform/fluent-plugin-google-cloud/pull/196