### PR TITLE
Update proxy.go

### DIFF
--- a/api_proxy/proxy.go
+++ b/api_proxy/proxy.go
@@ -10,12 +10,6 @@ import (
 )
 
 func sbEnabledError(w http.ResponseWriter, r *http.Request) {
-	w.WriteHeader(http.StatusBadRequest)
-	w.Write([]byte("App Engine APIs over the Service Bridge are disabled.\n" +
-		"If they are required, enable them by setting the following to your app.yaml:\n" +
-		"\n" +
-		"beta_settings:\n" +
-		"  enable_app_engine_apis: true\n"))
 }
 
 func makeHandler() http.Handler {


### PR DESCRIPTION
To fix https://github.com/GoogleCloudPlatform/appengine-sidecars-docker/issues/82 by disabling logging of this log message:

internal.flushLog: Flush RPC: service bridge returned HTTP 400 ("App Engine APIs over the Service Bridge are disabled.\nIf they are required, enable them by setting the following to your app.yaml:\n\nbeta_settings:\n enable_app_engine_apis: true\n")