### PR TITLE
Fixed return datatype incompatibility

### DIFF
--- a/third_party/iap_jwt_verify_nginx/src/jwt.cc
+++ b/third_party/iap_jwt_verify_nginx/src/jwt.cc
@@ -74,7 +74,7 @@ std::unique_ptr<Jwt> Jwt::parse_from_string(const std::string &jwt_str) {
   std::unique_ptr<const uint8_t[]>
       signature_bytes = url_safe_base64_decode(parts[2], &signature_length);
   if (signature_bytes == nullptr) {
-    return false;
+    return nullptr;
   }
 
   return std::unique_ptr<Jwt>(new (std::nothrow) Jwt(


### PR DESCRIPTION
This PR fixes the ESP build error on gLinux Rodete

$ g++ --version
g++ (Debian 6.3.0-18) 6.3.0 20170516

ERROR: /usr/local/google/home/jaebong/.cache/bazel/_bazel_jaebong/2d2a51155bb03044e06c3369c2128c3e/external/iap_jwt_verify_nginx/third_party/iap_jwt_verify_nginx/src/BUILD:63:1: C++ compilation of rule '@iap_jwt_verify_nginx//third_party/iap_jwt_verify_nginx/src:iap_jwt_verification' failed (Exit 1).
external/iap_jwt_verify_nginx/third_party/iap_jwt_verify_nginx/src/jwt.cc: In static member function 'static std::unique_ptr<google::cloud::iap::Jwt> google::cloud::iap::Jwt::parse_from_string(const string&)':
external/iap_jwt_verify_nginx/third_party/iap_jwt_verify_nginx/src/jwt.cc:77:12: error: could not convert 'false' from 'bool' to 'std::unique_ptr<google::cloud::iap::Jwt>'
     return false;
            ^~~~~
Target //src/nginx/main:nginx-esp failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 2.747s, Critical Path: 0.46s
