### PR TITLE
Remove misleading error message with service bridge

### DIFF
--- a/api_proxy/proxy.go
+++ b/api_proxy/proxy.go
@@ -11,11 +11,7 @@ import (
 
 func sbEnabledError(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusBadRequest)
-	w.Write([]byte("App Engine APIs over the Service Bridge are disabled.\n" +
-		"If they are required, enable them by setting the following to your app.yaml:\n" +
-		"\n" +
-		"beta_settings:\n" +
-		"  enable_app_engine_apis: true\n"))
+	w.Write([]byte("App Engine APIs over the Service Bridge are disabled.\n"))
 }
 
 func makeHandler() http.Handler {


### PR DESCRIPTION
Regarding to #82 , this removes the misleading part of the error message.