### PR TITLE
Add upstream status code to fluentd logging.

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -105,7 +105,7 @@
   # in place of the standard time capture, which grants us the ability to do
   # sub-second granular logs.
   # When making changes here, test with http://fluentular.herokuapp.com .
-  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +(?<protocol>\S*))?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^\/\"]*)[^\"]*")?(?: timestampSeconds="(?<timestampSeconds>[^\.\"]*)\.(?<timestampNanos>[^\"]*)")?(?: latencySeconds="(?<latencySeconds>[^\"]*)")?(?: x-forwarded-for="(?:-|(?<realClientIP>[^\,\"-]+),?)[^\"]*")?(?: appLatencySeconds="(?<appLatencySeconds>[^\"]*)")?.*$/
+  format /^(?<remote>[^ ]*) (?<host>[^ ]*) (?<user>[^ ]*) \[(?<time>[^\]]*)\] "(?<method>\S+)(?: +(?<path>[^\"]*) +(?<protocol>\S*))?" (?<code>[^ ]*) (?<size>[^ ]*)(?: "(?<referer>[^\"]*)" "(?<agent>[^\"]*)")?(?: tracecontext="(?<traceId>[^\/\"]*)[^\"]*")?(?: timestampSeconds="(?<timestampSeconds>[^\.\"]*)\.(?<timestampNanos>[^\"]*)")?(?: latencySeconds="(?<latencySeconds>[^\"]*)")?(?: x-forwarded-for="(?:-|(?<realClientIP>[^\,\"-]+),?)[^\"]*")?(?: appLatencySeconds="(?<appLatencySeconds>[^\"]*)")?(?: appStatusCode="(?<appStatusCode>[^\"]*)")?.*$/
   time_format %d/%b/%Y:%H:%M:%S %z
   path /var/log/nginx/access.log
   pos_file /var/tmp/fluentd.nginx-access.pos
@@ -211,7 +211,7 @@
     trace "${record[\"traceId\"]}"
   </record>
   renew_record true
-  keep_keys time,traceId,timestampSeconds,timestampNanos,latencySeconds,appLatencySeconds,instanceName
+  keep_keys time,traceId,timestampSeconds,timestampNanos,latencySeconds,appLatencySeconds,appStatusCode,instanceName
 </filter>
 
 # Docker container logs go through the from_docker container


### PR DESCRIPTION
Add upstream status code to be able to differentiate between nginx reported status codes and app container status codes.