### PR TITLE
Added start_esp argument to extract the second to the last part of X-Forwarded-For header

### DIFF
--- a/nginx_proxy/start_nginx.sh
+++ b/nginx_proxy/start_nginx.sh
@@ -132,6 +132,8 @@ fi
 if [[ "${ENDPOINTS_ROLLOUT_STRATEGY}" ]]; then
   cmd+=" --rollout_strategy \"${ENDPOINTS_ROLLOUT_STRATEGY}\""
 fi
+cmd+=" --client_ip_header \"X-Forwarded-For\""
+cmd+=" --client_ip_position -2"
 
 # Start nginx
 eval $cmd || exit $?


### PR DESCRIPTION
In the GAE Flex environment, the real client IP address is located at the second from the last of the X-Forwarded-For header.
To extract client IP address, ESP introduced new arguments --client_ip_header and --client_ip_position.
Required version of endpoints-runtime is 1.15.0 or later.

