### PR TITLE
Add exports_files(["LICENSE"]) directive to root BUILD file

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -15,6 +15,8 @@
 
 licenses(["notice"])
 
+exports_files(["LICENSE"])
+
 package(
     default_visibility = [
          "//visibility:public",


### PR DESCRIPTION
This is required by Google open source licensing policies.