### PR TITLE
api-verifier: add cloudbuild.yaml + update Dockerfile for GCB

### DIFF
--- a/api_verifier/Dockerfile
+++ b/api_verifier/Dockerfile
@@ -7,7 +7,8 @@
 #                 be constructed via the standard environment variables or
 #                 metadata.
 
-FROM gcr.io/google_appengine/python-compat
+ARG BASE_IMAGE_TAG=latest
+FROM gcr.io/google_appengine/python-compat:${BASE_IMAGE_TAG}
 ADD . /home/vmagent/api_verifier
 WORKDIR /home/vmagent/api_verifier
 ENTRYPOINT ["./api_verifier.py"]

--- a/api_verifier/cloudbuild.yaml
+++ b/api_verifier/cloudbuild.yaml
@@ -1,0 +1,17 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/api-verifier:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/api-verifier:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/api-verifier:latest'
+  - 'gcr.io/$PROJECT_ID/api-verifier:${_RC_NAME}'


### PR DESCRIPTION
This adds a cloudbuild.yaml file and updates the Dockerfile so that we
can build this using Google Container Builder.

The cloudbuild.yaml file produces an image with two tags: `latest` and a
name that's passed in by the user via a command line flag to `gcloud
container builds submit`.

I'm going to be making these updates for all the containers, but I
wanted to do this one first because it's one of the simpler ones (it
doesn't need any additional steps).