### PR TITLE
iap-watcher: add cloudbuild.yaml + update Dockerfile for GCB

### DIFF
--- a/iap_watcher/Dockerfile
+++ b/iap_watcher/Dockerfile
@@ -1,7 +1,8 @@
 # Dockerfile extending the debian8 image to run iap_watcher.py to auto
 # update IAP state and verifier keys.
 
-FROM gcr.io/google_appengine/debian8
+ARG BASE_IMAGE_TAG=latest
+FROM gcr.io/google_appengine/debian8:${BASE_IMAGE_TAG}
 
 RUN apt-get update && \
     apt-get upgrade -y && \

--- a/iap_watcher/cloudbuild.yaml
+++ b/iap_watcher/cloudbuild.yaml
@@ -1,0 +1,17 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/iap-watcher:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/iap-watcher:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/iap-watcher:latest'
+  - 'gcr.io/$PROJECT_ID/iap-watcher:${_RC_NAME}'


### PR DESCRIPTION
This adds a cloudbuild.yaml file and updates the Dockerfile so that we
can build this using Google Container Builder.

The cloudbuild.yaml file produces an image with two tags: latest and a
name that's passed in by the user via a command line flag to gcloud
container builds submit.

See also #101.