### PR TITLE
fluentd-logger: add cloudbuild.yaml + update Dockerfile for GCB

### DIFF
--- a/fluentd_logger/Dockerfile
+++ b/fluentd_logger/Dockerfile
@@ -1,6 +1,8 @@
 # To run:
 # docker run -d -v /var/log:/var/log:rw -v /var/lib/docker:/var/lib/docker:rw
-FROM gcr.io/google_appengine/base
+
+ARG BASE_IMAGE_TAG=latest
+FROM gcr.io/google_appengine/base:${BASE_IMAGE_TAG}
 RUN apt-get -q update && \
     apt-get -y install apt-utils adduser ca-certificates curl lsb-release build-essential && \
     apt-get clean && \

--- a/fluentd_logger/cloudbuild.yaml
+++ b/fluentd_logger/cloudbuild.yaml
@@ -1,0 +1,18 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/fluentd-logger:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/fluentd-logger:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/fluentd-logger:latest'
+  - 'gcr.io/$PROJECT_ID/fluentd-logger:${_RC_NAME}'
+timeout: 2000s


### PR DESCRIPTION
This adds a cloudbuild.yaml file and updates the Dockerfile so that we
can build this using Google Container Builder.

The cloudbuild.yaml file produces an image with two tags: latest and a
name that's passed in by the user via a command line flag to gcloud
container builds submit.

See also #101.