### PR TITLE
nginx-proxy: add cloudbuild.yaml + update Dockerfile for GCB

### DIFF
--- a/nginx_proxy/Dockerfile
+++ b/nginx_proxy/Dockerfile
@@ -1,6 +1,7 @@
 # Nginx Proxy that forwards requests into the appengine application.
 
-FROM gcr.io/google_appengine/base
+ARG BASE_IMAGE_TAG=latest
+FROM gcr.io/google_appengine/base:${BASE_IMAGE_TAG}
 
 # Add the Cloud SDK distribution URI as a package source
 # Import the Google Cloud public key

--- a/nginx_proxy/cloudbuild.yaml
+++ b/nginx_proxy/cloudbuild.yaml
@@ -1,0 +1,17 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/nginx-proxy:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/nginx-proxy:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/nginx-proxy:latest'
+  - 'gcr.io/$PROJECT_ID/nginx-proxy:${_RC_NAME}'


### PR DESCRIPTION
This adds a cloudbuild.yaml file and updates the Dockerfile so that we
can build this using Google Container Builder.

The cloudbuild.yaml file produces an image with two tags: latest and a
name that's passed in by the user via a command line flag to gcloud
container builds submit.

See also #101.