### PR TITLE
api-proxy: add cloudbuild.yaml file for GCR

### DIFF
--- a/api_proxy/cloudbuild.yaml
+++ b/api_proxy/cloudbuild.yaml
@@ -1,0 +1,24 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/go'
+    args: ['build', '-o', 'api_proxy-linux-amd64', '.']
+    env: [
+      'CGO_ENABLED=0',
+      'GOOS=linux',
+      'GOARCH=amd64'
+    ]
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/api-proxy:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/api-proxy:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/api-proxy:latest'
+  - 'gcr.io/$PROJECT_ID/api-proxy:${_RC_NAME}'


### PR DESCRIPTION
This adds a cloudbuild.yaml file and so that we can build this using
Google Container Builder.

The cloudbuild.yaml file produces an image with two tags: latest and a
name that's passed in by the user via a command line flag to gcloud
container builds submit. It also builds the go binary used by the Docker
container.

See also #101.