### PR TITLE
cloudsql-proxy: add cloudbuild.yaml file for GCR

### DIFF
--- a/cloud_sql_proxy/cloudbuild.yaml
+++ b/cloud_sql_proxy/cloudbuild.yaml
@@ -1,0 +1,40 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['clone', 'https://github.com/GoogleCloudPlatform/cloudsql-proxy']
+    dir: 'gopath/src/github.com/GoogleCloudPlatform'
+  - name: 'gcr.io/cloud-builders/git'
+    args: ['checkout', '571947b0f240c8b2fa4d163065e5b155920ddfa9']
+    dir: 'gopath/src/github.com/GoogleCloudPlatform/cloudsql-proxy'
+  - name: 'gcr.io/cloud-builders/go'
+    args: ['get', '-d', 'github.com/GoogleCloudPlatform/cloudsql-proxy/...']
+    env: ['GOPATH=/workspace/gopath']
+  - name: 'gcr.io/cloud-builders/go'
+    args: [
+      'build',
+      '-a',
+      '-installsuffix', 'cgo',
+      '-o', '/workspace/cloud_sql_proxy',
+      'github.com/GoogleCloudPlatform/cloudsql-proxy/cmd/cloud_sql_proxy/'
+    ]
+    env: [
+      'GOPATH=/workspace/gopath',
+      'CGO_ENABLED=0',
+      'GOOS=linux'
+    ]
+    dir: 'gopath/src/github.com/GoogleCloudPlatform/cloudsql-proxy'
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/cloudsql-proxy:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/cloudsql-proxy:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/cloudsql-proxy:latest'
+  - 'gcr.io/$PROJECT_ID/cloudsql-proxy:${_RC_NAME}'


### PR DESCRIPTION
This adds a cloudbuild.yaml file and so that we can build this using
Google Container Builder.

The cloudbuild.yaml file produces an image with two tags: latest and a
name that's passed in by the user via a command line flag to gcloud
container builds submit.

It also builds the go binary used by the Docker container, which is
pinned to a specific commit.

See also #101.