### PR TITLE
memcache-proxy: add cloudbuild.yaml + custom Dockerfile.builder for GCR

### DIFF
--- a/memcache_proxy/Dockerfile.builder
+++ b/memcache_proxy/Dockerfile.builder
@@ -1,0 +1,7 @@
+# We just need a container with the go binary installed. I figured reusing the
+# cloud-builder one is the best way to go. (But it can't have the entrypoint
+# that the cloud builder one uses.)
+
+FROM gcr.io/cloud-builders/go
+
+ENTRYPOINT ["/bin/sh"]

--- a/memcache_proxy/Dockerfile.builder
+++ b/memcache_proxy/Dockerfile.builder
@@ -1,6 +1,6 @@
-# We just need a container with the go binary installed. I figured reusing the
-# cloud-builder one is the best way to go. (But it can't have the entrypoint
-# that the cloud builder one uses.)
+# We just need a container with the go binary installed. Reusing the
+# cloud-builder one is the easiest way to do this. (But it can't have the
+# entrypoint that the cloud builder one uses.)
 
 FROM gcr.io/cloud-builders/go
 

--- a/memcache_proxy/build.sh
+++ b/memcache_proxy/build.sh
@@ -16,7 +16,7 @@
 set -e
 
 echo "Preparing build ..."
-export GOPATH=$(mktemp --directory)
+export GOPATH=$(mktemp -d)
 mkdir -p $GOPATH/src $GOPATH/pkg
 
 go get google.golang.org/appengine/internal

--- a/memcache_proxy/cloudbuild.yaml
+++ b/memcache_proxy/cloudbuild.yaml
@@ -1,0 +1,21 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-f', 'Dockerfile.builder', '-t', 'script-runner', '.']
+  - name: 'script-runner'
+    args: ['./build.sh']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/memcache-proxy:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/memcache-proxy:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/memcache-proxy:latest'
+  - 'gcr.io/$PROJECT_ID/memcache-proxy:${_RC_NAME}'


### PR DESCRIPTION
This adds a cloudbuild.yaml config file as well as a custom Dockerfile
to specify the build environment for this sidecar so that we can build
it with Google Container Builder.

The cloudbuild.yaml file produces an image with two tags: latest and a
name that's passed in by the user via a command line flag to gcloud
container builds submit. It also builds a special container used to run
the `build.sh` script, but this container is not saved externally.

Also, I updated the `build.sh` script to use `mktemp -d` instead of
`--directory` because the version of `mktemp` that container builder
uses doesn't support `--directory`. This should be backwards compatible.