### PR TITLE
Add Dockerfile + cloudbuild.yaml for base Docker image

### DIFF
--- a/base/Dockerfile
+++ b/base/Dockerfile
@@ -1,0 +1,11 @@
+FROM gcr.io/google-appengine/debian8
+# Clean any CMD that might be inherited from previous image, because that
+# will pollute our ENTRYPOINT, see
+# http://docs.docker.io/en/latest/reference/builder/#entrypoint.
+CMD []
+ENV DEBIAN_FRONTEND noninteractive
+ENV PORT 8080
+RUN apt-get -q update && \
+    apt-get install --no-install-recommends -y -q ca-certificates && \
+    apt-get -y -q upgrade && \
+    rm /var/lib/apt/lists/*_*

--- a/base/cloudbuild.yaml
+++ b/base/cloudbuild.yaml
@@ -1,0 +1,17 @@
+# Config for building with Google Container Builder
+#
+# This produces a container with two tags, "latest" and _RC_NAME, which must be
+# specified via a command-line flag.
+#
+# Run with:
+#   gcloud container builds submit --config cloudbuild.yaml . \
+#     --substitutions=_RC_NAME=20180101-RC00
+
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/base:latest', '.']
+  - name: 'gcr.io/cloud-builders/docker'
+    args: ['build', '-t', 'gcr.io/${PROJECT_ID}/base:${_RC_NAME}', '.']
+images:
+  - 'gcr.io/$PROJECT_ID/base:latest'
+  - 'gcr.io/$PROJECT_ID/base:${_RC_NAME}'


### PR DESCRIPTION
This is the coveted gcr.io/google-appengine/base that some of the other
Docker images depends on.