### PR TITLE
Fix binary arch issue in memcache-proxy

### DIFF
--- a/memcache_proxy/build.sh
+++ b/memcache_proxy/build.sh
@@ -16,7 +16,7 @@
 set -e
 
 echo "Preparing build ..."
-export GOPATH=$(mktemp -d)
+readonly GOPATH="${GOPATH:-$(mktemp -d)}"
 mkdir -p $GOPATH/src $GOPATH/pkg
 
 go get google.golang.org/appengine/internal
@@ -24,7 +24,7 @@ cp -R $GOPATH/src/google.golang.org/appengine/internal $GOPATH/src/google.golang
 sed -i 's|instance/attributes/gae_minor_version|instance/attributes/gae_backend_minor_version|g' $GOPATH/src/google.golang.org/appengine/notreallyinternal/identity_vm.go
 sed -i 's|"google\.golang\.org/appengine/internal"|internal "google\.golang\.org/appengine/notreallyinternal"|g' $GOPATH/src/google.golang.org/appengine/notreallyinternal/aetesting/fake.go
 
-DEST=$GOPATH/src
+readonly DEST=$GOPATH/src
 
 echo "Building in $DEST"
 
@@ -39,4 +39,3 @@ echo "Testing in $DEST"
 go test $DEST/dtog/dtog.go $DEST/dtog/dtog_test.go
 
 echo "Done, your binary is here ./memcachep"
-

--- a/memcache_proxy/cloudbuild.yaml
+++ b/memcache_proxy/cloudbuild.yaml
@@ -12,6 +12,14 @@ steps:
     args: ['build', '-f', 'Dockerfile.builder', '-t', 'script-runner', '.']
   - name: 'script-runner'
     args: ['./build.sh']
+    env: ['GOPATH=/workspace']
+  - name: 'gcr.io/cloud-builders/go'
+    args: ['build', '-o', 'memcachep', 'main/memcached2g.go']
+    env: [
+      'CGO_ENABLED=0',
+      'GOOS=linux',
+      'GOARCH=amd64'
+    ]
   - name: 'gcr.io/cloud-builders/docker'
     args: ['build', '-t', 'gcr.io/${PROJECT_ID}/memcache-proxy:latest', '.']
   - name: 'gcr.io/cloud-builders/docker'


### PR DESCRIPTION
We need to compile with these flags, which aren't the default for Container Builder.

This whole things is pretty hacky, so I just added the workaround of least resistance:
manually building the binary again after running the build.sh script.