### PR TITLE
Update GO_VERSION to stop Travis flakes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: precise
 
 matrix:
   include:
-  - env: GO_VERSION=1.10.3
+  - env: GO_VERSION=1.9.7
 
 before_install:
 - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,7 @@ dist: precise
 
 matrix:
   include:
-  - env: GO_VERSION=1.6.3
-  - env: GO_VERSION=1.7rc3
+  - env: GO_VERSION=1.10.3
 
 before_install:
 - pwd


### PR DESCRIPTION
Neither of the golang versions here are supported anymore, so let's update.