### PR TITLE
Fetch keys at a random time per-VM

### DIFF
--- a/iap_watcher/Dockerfile
+++ b/iap_watcher/Dockerfile
@@ -24,7 +24,7 @@ ENTRYPOINT [ \
     "--fetch_keys=True", \
     "--output_key_file=${OUTPUT_KEY_FILE}"]
 
-RUN echo "15 */1 * * * curl 'https://www.gstatic.com/iap/verify/public_key-jwk' > ${OUTPUT_KEY_FILE}" >> .tmp_cron
+RUN echo "$(($RANDOM%60)) * * * * curl 'https://www.gstatic.com/iap/verify/public_key-jwk' > ${OUTPUT_KEY_FILE}" >> .tmp_cron
 RUN crontab .tmp_cron
 RUN service cron start
 RUN rm .tmp_cron


### PR DESCRIPTION
This is to avoid hammering on the IAP key endpoint synchronously once-per-hour.