### PR TITLE
 Move "service cron start" into ENTRYPOINT

### DIFF
--- a/iap_watcher/Dockerfile
+++ b/iap_watcher/Dockerfile
@@ -17,14 +17,12 @@ RUN mkdir -p /home/vmagent/iap_watcher
 WORKDIR /home/vmagent/iap_watcher
 ADD iap_watcher.py .
 ENV OUTPUT_KEY_FILE /iap_watcher/iap_verify_keys.txt
-ENTRYPOINT [ \
-    "./iap_watcher.py", \
-    "--iap_metadata_key=AEF_IAP_state", \
-    "--output_state_file=/iap_watcher/iap_state", \
-    "--fetch_keys=True", \
-    "--output_key_file=${OUTPUT_KEY_FILE}"]
-
 RUN ["/bin/bash", "-c", "echo \"$(($RANDOM%60)) * * * * curl 'https://www.gstatic.com/iap/verify/public_key-jwk' > ${OUTPUT_KEY_FILE}\" >> .tmp_cron"]
 RUN crontab .tmp_cron
-RUN service cron start
 RUN rm .tmp_cron
+ENTRYPOINT [ \
+    "/bin/bash", \
+    "-c", \
+    "service cron start; ./iap_watcher.py --iap_metadata_key=AEF_IAP_state --output_state_file=/iap_watcher/iap_state --fetch_keys=True --output_key_file=${OUTPUT_KEY_FILE}"]
+
+

--- a/iap_watcher/Dockerfile
+++ b/iap_watcher/Dockerfile
@@ -24,5 +24,3 @@ ENTRYPOINT [ \
     "/bin/bash", \
     "-c", \
     "service cron start; ./iap_watcher.py --iap_metadata_key=AEF_IAP_state --output_state_file=/iap_watcher/iap_state --fetch_keys=True --output_key_file=${OUTPUT_KEY_FILE}"]
-
-


### PR DESCRIPTION
https://stackoverflow.com/questions/46235982/why-doesnt-service-cron-start-work-within-the-docker-file

Tested this new version; it behaves as expected.