### PR TITLE
Log logging.googleapis.com/trace field to enable Stackdriver tracing features

### DIFF
--- a/fluentd_logger/managed_vms.conf
+++ b/fluentd_logger/managed_vms.conf
@@ -215,6 +215,7 @@
       "protocol": "${record[\"protocol\"]}"
     }
     trace "${record[\"traceId\"]}"
+    "logging.googleapis.com/trace" "projects/#{ENV['GAE_PROJECT']}/traces/${record[\"traceId\"]}"
   </record>
   renew_record true
   keep_keys time,traceId,timestampSeconds,timestampNanos,latencySeconds,appLatencySeconds,instanceName


### PR DESCRIPTION
Log logging.googleapis.com/trace field to enable Stackdriver tracing features for ngnix request logs. Keep existing traceId field untouched in order to keep backward compatibility.