### PR TITLE
Update the go version used by the travis tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: precise
 
 matrix:
   include:
-  - env: GO_VERSION=1.13.7
+  - env: GO_VERSION=1.11.13
 
 before_install:
 - pwd

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ dist: precise
 
 matrix:
   include:
-  - env: GO_VERSION=1.9.7
+  - env: GO_VERSION=1.13.7
 
 before_install:
 - pwd

--- a/testing/all.bash
+++ b/testing/all.bash
@@ -36,7 +36,12 @@ which go
 go env
 # NOTE(cbro): skip memcache_proxy, it is not go-gettable.
 GO_PKGS=$(go list -v github.com/GoogleCloudPlatform/appengine-sidecars-docker/... | grep -v memcache_proxy)
-go test -v $GO_PKGS
+GO_PKGS_NO_MODULES=$(echo $GO_PKGS | grep -e api_proxy)
+GO_PKGS_WITH_MODULES=$(echo $GO_PKGS | grep -v api_proxy)
+
+go test -v $GO_PKGS_NO_MODULES
+
+env GO111MODULE=on go test -v $GO_PKGS_WITH_MODULES
 
 #### go vet, go fmt, etc.
 


### PR DESCRIPTION
This allows the travis tests to work with go modules.