### PR TITLE
Separate metrics pipeline for dockerstats.

### DIFF
--- a/opentelemetry_collector/opentelemetry_config.yaml
+++ b/opentelemetry_collector/opentelemetry_config.yaml
@@ -17,10 +17,17 @@ processors:
 exporters:
   stackdriver:
     metric_prefix: appengine.googleapis.com/flex/internal
+  stackdriver/instance:
+    # TODO: Change to appengine.googleapis.com once ACLs allow it.
+    metric_prefix: custom.googleapis.com/flex/instance
 
 service:
   pipelines:
     metrics:
-      receivers: [vmimageage, dockerstats]
+      receivers: [vmimageage]
       processors: [resource]
       exporters: [stackdriver]
+    metrics/instance:
+      receivers: [dockerstats]
+      processors: [resource]
+      exporters: [stackdriver/instance]


### PR DESCRIPTION
dockerstats metrics are intended for a different prefix than VM Image
age metrics. Eventually, they'd be written to
appengine.googleapis.com/flex/instance/, but until ACLs allow for it,
write them to custom.googleapis.com/flex/instance instead.