### PR TITLE
Update metric prefix for stackdriver/instance

### DIFF
--- a/opentelemetry_collector/opentelemetry_config.yaml
+++ b/opentelemetry_collector/opentelemetry_config.yaml
@@ -18,8 +18,7 @@ exporters:
   stackdriver:
     metric_prefix: appengine.googleapis.com/flex/internal
   stackdriver/instance:
-    # TODO: Change to appengine.googleapis.com once ACLs allow it.
-    metric_prefix: custom.googleapis.com/flex/instance
+    metric_prefix: appengine.googleapis.com/flex/instance
 
 service:
   pipelines:


### PR DESCRIPTION
Usage of custom.googleapis.com is not free. As we get ready to rollout the collector on Flex, we want to make sure that we don't accidentally roll it out in the wrong domain and cause billing issues.