### PR TITLE
Use zap.Logger instead of glog.

### DIFF
--- a/opentelemetry_collector/go.mod
+++ b/opentelemetry_collector/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.3.5
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stackdriverexporter v0.6.0

--- a/opentelemetry_collector/receiver/dockerstats/factory.go
+++ b/opentelemetry_collector/receiver/dockerstats/factory.go
@@ -51,7 +51,7 @@ func (f *Factory) CreateMetricsReceiver(ctx context.Context, params component.Re
 		return nil, fmt.Errorf("invalid scrape duration: %v, must be positive", c.ScrapeInterval)
 	}
 
-	s, err := newScraper(c.ScrapeInterval, nextConsumer)
+	s, err := newScraper(c.ScrapeInterval, nextConsumer, params.Logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create dockerstats scraper: %v", err)
 	}

--- a/opentelemetry_collector/receiver/dockerstats/scraper_test.go
+++ b/opentelemetry_collector/receiver/dockerstats/scraper_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/docker/docker/api/types/container"
 	"github.com/docker/docker/client"
 	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap"
 
 	"go.opentelemetry.io/collector/consumer/consumerdata"
 	"go.opentelemetry.io/collector/consumer/pdata"
@@ -169,6 +170,7 @@ func TestScraperExport(t *testing.T) {
 		docker:         &fakeDocker{},
 		scrapeInterval: 10 * time.Second,
 		now:            fakeNow,
+		logger:         zap.NewNop(),
 	}
 
 	s.export()
@@ -237,6 +239,7 @@ func TestScraperContinuesOnError(t *testing.T) {
 		docker:         &alwaysFailDocker{},
 		scrapeInterval: 1 * time.Second,
 		done:           make(chan bool),
+		logger:         zap.NewNop(),
 	}
 	s.start()
 	time.Sleep(6 * time.Second)


### PR DESCRIPTION
Fixes #147.

Opentelemetry already uses zap logger for various other components. We
simply plumb it through to dockerstats scraper and use it there.