### PR TITLE
Switch CPU metrics to use "seconds" as unit.

### DIFF
--- a/opentelemetry_collector/go.mod
+++ b/opentelemetry_collector/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/census-instrumentation/opencensus-proto v0.2.1
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1
-	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/golang/protobuf v1.3.5
 	github.com/hashicorp/golang-lru v0.5.4 // indirect
 	github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stackdriverexporter v0.6.0

--- a/opentelemetry_collector/receiver/dockerstats/scraper.go
+++ b/opentelemetry_collector/receiver/dockerstats/scraper.go
@@ -29,17 +29,17 @@ var (
 	}
 
 	cpuUsageDesc = &mpb.MetricDescriptor{
-		Name:        "container/cpu/usage",
+		Name:        "container/cpu/usage_time",
 		Description: "Total CPU time consumed",
-		Unit:        "nanoseconds",
-		Type:        mpb.MetricDescriptor_CUMULATIVE_INT64,
+		Unit:        "seconds",
+		Type:        mpb.MetricDescriptor_CUMULATIVE_DOUBLE,
 		LabelKeys:   []*mpb.LabelKey{containerNameLabel},
 	}
 	cpuLimitDesc = &mpb.MetricDescriptor{
 		Name:        "container/cpu/limit",
 		Description: "CPU time limit (where applicable)",
-		Unit:        "nanoseconds",
-		Type:        mpb.MetricDescriptor_GAUGE_INT64,
+		Unit:        "seconds",
+		Type:        mpb.MetricDescriptor_GAUGE_DOUBLE,
 		LabelKeys:   []*mpb.LabelKey{containerNameLabel},
 	}
 	memUsageDesc = &mpb.MetricDescriptor{
@@ -216,7 +216,7 @@ func (s *scraper) usageStatsToMetrics(stats *types.StatsJSON, labelValues []*mpb
 		{
 			MetricDescriptor: cpuUsageDesc,
 			Timeseries: []*mpb.TimeSeries{
-				metricgenerator.MakeInt64TimeSeries(int64(stats.CPUStats.CPUUsage.TotalUsage), s.startTime, s.now(), labelValues),
+				metricgenerator.MakeDoubleTimeSeries(time.Duration(stats.CPUStats.CPUUsage.TotalUsage).Seconds(), s.startTime, s.now(), labelValues),
 			},
 		},
 		// Unfortunately, Docker API doesn't expose CPU Limits via CPUStats API. That information
@@ -290,7 +290,7 @@ func (s *scraper) containerInfoToMetrics(info containerInfo, labelValues []*mpb.
 		metrics = append(metrics, &mpb.Metric{
 			MetricDescriptor: cpuLimitDesc,
 			Timeseries: []*mpb.TimeSeries{
-				metricgenerator.MakeInt64TimeSeries(info.cpuLimit, s.startTime, s.now(), labelValues),
+				metricgenerator.MakeDoubleTimeSeries(time.Duration(info.cpuLimit).Seconds(), s.startTime, s.now(), labelValues),
 			},
 		})
 	}

--- a/opentelemetry_collector/receiver/dockerstats/scraper_test.go
+++ b/opentelemetry_collector/receiver/dockerstats/scraper_test.go
@@ -176,23 +176,23 @@ func TestScraperExport(t *testing.T) {
 	s.export()
 
 	data := pdatautil.MetricsToMetricsData(c.metrics)[0]
-	verifyContainerMetricValue(t, data, "container/cpu/usage", "name1a", 100000000)
+	verifyContainerMetricDoubleValue(t, data, "container/cpu/usage_time", "name1a", 0.1)
 	verifyContainerMetricAbsent(t, data, "container/cpu/limit", "name1a")
-	verifyContainerMetricValue(t, data, "container/memory/usage", "name1a", 33)
-	verifyContainerMetricValue(t, data, "container/memory/limit", "name1a", 66)
-	verifyContainerMetricValue(t, data, "container/network/received_bytes_count", "name1a", 111)
-	verifyContainerMetricValue(t, data, "container/network/sent_bytes_count", "name1a", 222)
-	verifyContainerMetricValue(t, data, "container/uptime", "name1a", 43200)
-	verifyContainerMetricValue(t, data, "container/restart_count", "name1a", 3)
-	verifyContainerMetricValue(t, data, "container/cpu/usage", "id2", 200000000)
-	verifyContainerMetricValue(t, data, "container/cpu/limit", "id2", 500000000)
-	verifyContainerMetricValue(t, data, "container/memory/usage", "id2", 44)
-	verifyContainerMetricValue(t, data, "container/memory/limit", "id2", 88)
-	verifyContainerMetricValue(t, data, "container/network/received_bytes_count", "id2", 555)
-	verifyContainerMetricValue(t, data, "container/network/sent_bytes_count", "id2", 777)
-	verifyContainerMetricValue(t, data, "container/uptime", "id2", 86400)
-	verifyContainerMetricValue(t, data, "container/restart_count", "id2", 5)
-	verifyContainerMetricAbsent(t, data, "container/cpu/usage", "name3")
+	verifyContainerMetricInt64Value(t, data, "container/memory/usage", "name1a", 33)
+	verifyContainerMetricInt64Value(t, data, "container/memory/limit", "name1a", 66)
+	verifyContainerMetricInt64Value(t, data, "container/network/received_bytes_count", "name1a", 111)
+	verifyContainerMetricInt64Value(t, data, "container/network/sent_bytes_count", "name1a", 222)
+	verifyContainerMetricInt64Value(t, data, "container/uptime", "name1a", 43200)
+	verifyContainerMetricInt64Value(t, data, "container/restart_count", "name1a", 3)
+	verifyContainerMetricDoubleValue(t, data, "container/cpu/usage_time", "id2", 0.2)
+	verifyContainerMetricDoubleValue(t, data, "container/cpu/limit", "id2", 0.5)
+	verifyContainerMetricInt64Value(t, data, "container/memory/usage", "id2", 44)
+	verifyContainerMetricInt64Value(t, data, "container/memory/limit", "id2", 88)
+	verifyContainerMetricInt64Value(t, data, "container/network/received_bytes_count", "id2", 555)
+	verifyContainerMetricInt64Value(t, data, "container/network/sent_bytes_count", "id2", 777)
+	verifyContainerMetricInt64Value(t, data, "container/uptime", "id2", 86400)
+	verifyContainerMetricInt64Value(t, data, "container/restart_count", "id2", 5)
+	verifyContainerMetricAbsent(t, data, "container/cpu/usage_time", "name3")
 	verifyContainerMetricAbsent(t, data, "container/cpu/limit", "name3")
 	verifyContainerMetricAbsent(t, data, "container/memory/usage", "name3")
 	verifyContainerMetricAbsent(t, data, "container/memory/limit", "name3")
@@ -202,7 +202,7 @@ func TestScraperExport(t *testing.T) {
 	verifyContainerMetricAbsent(t, data, "container/restart_count", "name3")
 }
 
-func verifyContainerMetricValue(t *testing.T, data consumerdata.MetricsData, name, label string, value int64) {
+func verifyContainerMetricInt64Value(t *testing.T, data consumerdata.MetricsData, name, label string, value int64) {
 	var metric *mpb.Metric
 	for _, m := range data.Metrics {
 		if m.MetricDescriptor.Name == name && m.Timeseries[0].LabelValues[0].Value == label {
@@ -214,6 +214,20 @@ func verifyContainerMetricValue(t *testing.T, data consumerdata.MetricsData, nam
 		return
 	}
 	assert.Equal(t, value, metric.Timeseries[0].Points[0].GetInt64Value())
+}
+
+func verifyContainerMetricDoubleValue(t *testing.T, data consumerdata.MetricsData, name, label string, value float64) {
+	var metric *mpb.Metric
+	for _, m := range data.Metrics {
+		if m.MetricDescriptor.Name == name && m.Timeseries[0].LabelValues[0].Value == label {
+			metric = m
+		}
+	}
+	if metric == nil {
+		t.Errorf("Unable to find metric %q", name)
+		return
+	}
+	assert.Equal(t, value, metric.Timeseries[0].Points[0].GetDoubleValue())
 }
 
 func verifyContainerMetricAbsent(t *testing.T, data consumerdata.MetricsData, name, label string) {

--- a/opentelemetry_collector/receiver/metricgenerator/metric_generator.go
+++ b/opentelemetry_collector/receiver/metricgenerator/metric_generator.go
@@ -30,6 +30,15 @@ func MakeInt64TimeSeries(val int64, startTime, now time.Time, labels []*metricsp
 	}
 }
 
+// MakeDoubleTimeSeries generates a proto representation of a timeseries containing a single point for an double metric.
+func MakeDoubleTimeSeries(val float64, startTime, now time.Time, labels []*metricspb.LabelValue) *metricspb.TimeSeries {
+	return &metricspb.TimeSeries{
+		StartTimestamp: TimeToTimestamp(startTime),
+		LabelValues:    labels,
+		Points:         []*metricspb.Point{{Timestamp: TimeToTimestamp(now), Value: &metricspb.Point_DoubleValue{DoubleValue: val}}},
+	}
+}
+
 // MakeExponentialBucketOptions generates a proto representation of a config which,
 // defines a distribution's bounds. This defines maxExponent + 2 buckets. The boundaries for bucket
 // index i are:

--- a/opentelemetry_collector/receiver/metricgenerator/metric_generator_test.go
+++ b/opentelemetry_collector/receiver/metricgenerator/metric_generator_test.go
@@ -53,6 +53,34 @@ func Test_MakeInt64TimeSeries(t *testing.T) {
 	assert.Equal(t, timeseries, expectedTimeseries)
 }
 
+func Test_MakeDoubleTimeSeries(t *testing.T) {
+	seconds1 := int64(1541015015)
+	seconds2 := int64(1541015016)
+	nanoseconds := int64(123456789)
+	startTime := time.Unix(seconds1, nanoseconds)
+	currentTime := time.Unix(seconds2, nanoseconds)
+	labelValues := []*metricspb.LabelValue{MakeLabelValue("test_label")}
+	timeseries := MakeDoubleTimeSeries(1.1, startTime, currentTime, labelValues)
+
+	expectedTimeseries := &metricspb.TimeSeries{
+		StartTimestamp: &timestamp.Timestamp{
+			Seconds: seconds1,
+			Nanos:   int32(nanoseconds),
+		},
+		LabelValues: labelValues,
+		Points: []*metricspb.Point{{
+			Timestamp: &timestamp.Timestamp{
+				Seconds: seconds2,
+				Nanos:   int32(nanoseconds),
+			},
+			Value: &metricspb.Point_DoubleValue{
+				DoubleValue: 1.1,
+			},
+		}},
+	}
+	assert.Equal(t, timeseries, expectedTimeseries)
+}
+
 func Test_MakeExponentialBucketOptions(t *testing.T) {
 	bucketOptions := MakeExponentialBucketOptions(2, 5)
 	expectedBounds := []float64{1, 2, 4, 8, 16, 32}


### PR DESCRIPTION
This was recommended by the Stackdriver team to keep it consistent with
CPU usage metrics across GCP.