### PR TITLE
Rename vmimageagereceiver to vmagereceiver. 

### DIFF
--- a/opentelemetry_collector/components.go
+++ b/opentelemetry_collector/components.go
@@ -22,7 +22,7 @@ import (
 
 	"github.com/googlecloudplatform/appengine-sidecars-docker/opentelemetry_collector/receiver/dockerstats"
 	"github.com/googlecloudplatform/appengine-sidecars-docker/opentelemetry_collector/receiver/nginxreceiver"
-	"github.com/googlecloudplatform/appengine-sidecars-docker/opentelemetry_collector/receiver/vmimageagereceiver"
+	"github.com/googlecloudplatform/appengine-sidecars-docker/opentelemetry_collector/receiver/vmagereceiver"
 
 	"github.com/open-telemetry/opentelemetry-collector-contrib/exporter/stackdriverexporter"
 )
@@ -33,7 +33,7 @@ func components() (component.Factories, error) {
 	receivers, err := component.MakeReceiverFactoryMap(
 		dockerstats.NewFactory(),
 		nginxreceiver.NewFactory(),
-		vmimageagereceiver.NewFactory(),
+		vmagereceiver.NewFactory(),
 	)
 	if err != nil {
 		errs = append(errs, err)

--- a/opentelemetry_collector/go.sum
+++ b/opentelemetry_collector/go.sum
@@ -828,6 +828,7 @@ github.com/googleapis/gnostic v0.1.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTV
 github.com/googleapis/gnostic v0.3.0 h1:CcQijm0XKekKjP/YCz28LXVSpgguuB+nCxaSjCe09y0=
 github.com/googleapis/gnostic v0.3.0/go.mod h1:sJBsCZ4ayReDTBIg8b9dl28c5xFWyhBTVRp3pOg5EKY=
 github.com/googleapis/gnostic v0.4.0/go.mod h1:on+2t9HRStVgn95RSsFWFz+6Q0Snyqv1awfrALZdbtU=
+github.com/googlecloudplatform/appengine-sidecars-docker v0.0.0-20201119192143-9691aa1f3b32 h1:UvLcLi1Byu+H1bQ5vIYeTpKqxNvDnIsNGCAC1Yx9Yig=
 github.com/googleinterns/cloud-operations-api-mock v0.0.0-20200709193332-a1e58c29bdd3/go.mod h1:h/KNeRx7oYU4SpA4SoY7W2/NxDKEEVuwA6j9A27L4OI=
 github.com/gookit/color v1.2.4/go.mod h1:AhIE+pS6D4Ql0SQWbBeXPHw7gY0/sjHoA4s/n1KB7xg=
 github.com/gookit/color v1.2.5 h1:s1gzb/fg3HhkSLKyWVUsZcVBUo+R1TwEYTmmxH8gGFg=

--- a/opentelemetry_collector/opentelemetry_config.yaml
+++ b/opentelemetry_collector/opentelemetry_config.yaml
@@ -2,7 +2,7 @@ receivers:
   dockerstats:
   nginxstats:
     stats_url: @NGINX_STATS_URL@
-  vmimageage:
+  vmage:
     build_date: @BUILD_DATE@
     vm_image_name: @IMAGE_NAME@
 
@@ -27,7 +27,7 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [vmimageage, nginxstats]
+      receivers: [vmage, nginxstats]
       processors: [resource]
       exporters: [stackdriver]
     metrics/instance:

--- a/opentelemetry_collector/receiver/vmagereceiver/config.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/config.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	"time"
@@ -6,7 +6,7 @@ import (
 	"go.opentelemetry.io/collector/config/configmodels"
 )
 
-// Config defines the configuration for the VM image age receiver.
+// Config defines the configuration for the VM age receiver.
 type Config struct {
 	configmodels.ReceiverSettings `mapstructure:",squash"`
 	ExportInterval                time.Duration `mapstructure:"export_interval"`

--- a/opentelemetry_collector/receiver/vmagereceiver/config_test.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/config_test.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	"path"
@@ -26,15 +26,15 @@ func TestLoadConfig(t *testing.T) {
 
 	assert.Equal(t, len(cfg.Receivers), 2)
 
-	defaultReceiver := cfg.Receivers["vmimageage"]
+	defaultReceiver := cfg.Receivers["vmage"]
 	assert.Equal(t, defaultReceiver, factory.CreateDefaultConfig())
 
-	customReceiver := cfg.Receivers["vmimageage/customname"].(*Config)
+	customReceiver := cfg.Receivers["vmage/customname"].(*Config)
 	assert.Equal(t, customReceiver,
 		&Config{
 			ReceiverSettings: configmodels.ReceiverSettings{
 				TypeVal: typeStr,
-				NameVal: "vmimageage/customname",
+				NameVal: "vmage/customname",
 			},
 			ExportInterval: 10 * time.Minute,
 			BuildDate:      "2006-01-02T15:04:05Z07:00",

--- a/opentelemetry_collector/receiver/vmagereceiver/doc.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/doc.go
@@ -1,0 +1,5 @@
+// Package vmagereceiver generates and periodically emits metrics
+// related to time about the VM based on the config file, including metrics
+// about the VM image age and VM ready time. It is a metric receiver designed
+// to work with OpenTelemetry Collector.
+package vmagereceiver

--- a/opentelemetry_collector/receiver/vmagereceiver/factory.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/factory.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	"context"
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	typeStr = "vmimageage"
+	typeStr = "vmage"
 )
 
 // CreateDefaultConfig creates the default configuration for the receiver.
@@ -32,15 +32,15 @@ func createMetricsReceiver(
 ) (component.MetricsReceiver, error) {
 
 	cfg := config.(*Config)
-	collector := NewVMImageAgeCollector(cfg.ExportInterval, cfg.BuildDate, cfg.VMImageName, consumer, params.Logger)
+	collector := NewVMAgeCollector(cfg.ExportInterval, cfg.BuildDate, cfg.VMImageName, consumer, params.Logger)
 
 	receiver := &Receiver{
-		vmImageAgeCollector: collector,
+		vmAgeCollector: collector,
 	}
 	return receiver, nil
 }
 
-// NewFactory creates and returns a factory for the vm image age receiver.
+// NewFactory creates and returns a factory for the vm age receiver.
 func NewFactory() component.ReceiverFactory {
 	return receiverhelper.NewFactory(
 		typeStr,

--- a/opentelemetry_collector/receiver/vmagereceiver/factory_test.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/factory_test.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	"context"

--- a/opentelemetry_collector/receiver/vmagereceiver/metrics_receiver.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/metrics_receiver.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	"context"
@@ -7,9 +7,9 @@ import (
 	"go.opentelemetry.io/collector/component"
 )
 
-// Receiver is the type that provides Receiver functionaly for the VM image age metrics.
+// Receiver is the type that provides Receiver functionaly for the VM age metrics.
 type Receiver struct {
-	vmImageAgeCollector *VMImageAgeCollector
+	vmAgeCollector *VMAgeCollector
 
 	stopOnce  sync.Once
 	startOnce sync.Once
@@ -18,7 +18,7 @@ type Receiver struct {
 // Start starts the underlying VM metrics generator.
 func (receiver *Receiver) Start(ctx context.Context, host component.Host) error {
 	receiver.startOnce.Do(func() {
-		receiver.vmImageAgeCollector.StartCollection()
+		receiver.vmAgeCollector.StartCollection()
 	})
 	return nil
 }
@@ -26,7 +26,7 @@ func (receiver *Receiver) Start(ctx context.Context, host component.Host) error 
 // Shutdown stops and cancels the underlying VM metrics generator.
 func (receiver *Receiver) Shutdown(ctx context.Context) error {
 	receiver.stopOnce.Do(func() {
-		receiver.vmImageAgeCollector.StopCollection()
+		receiver.vmAgeCollector.StopCollection()
 	})
 	return nil
 }

--- a/opentelemetry_collector/receiver/vmagereceiver/testdata/config.yaml
+++ b/opentelemetry_collector/receiver/vmagereceiver/testdata/config.yaml
@@ -1,6 +1,6 @@
 receivers:
-  vmimageage:
-  vmimageage/customname:
+  vmage:
+  vmage/customname:
     export_interval: 10m
     build_date: 2006-01-02T15:04:05Z07:00
     vm_image_name: test_vm_image_name
@@ -14,6 +14,6 @@ exporters:
 service:
   pipelines:
     metrics:
-      receivers: [vmimageage]
+      receivers: [vmage]
       processors: [exampleprocessor]
       exporters: [exampleexporter]

--- a/opentelemetry_collector/receiver/vmagereceiver/vm_image_age_collector.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/vm_image_age_collector.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	"context"
@@ -15,9 +15,8 @@ import (
 	"github.com/googlecloudplatform/appengine-sidecars-docker/opentelemetry_collector/receiver/metricgenerator"
 )
 
-// VMImageAgeCollector is a struct that generates metrics based on the
-// VM image age in the config.
-type VMImageAgeCollector struct {
+// VMAgeCollector is a struct that generates metrics based on the VM age in the config.
+type VMAgeCollector struct {
 	consumer consumer.MetricsConsumer
 
 	startTime time.Time
@@ -37,14 +36,14 @@ const (
 	defaultExportInterval = 10 * time.Minute
 )
 
-// NewVMImageAgeCollector creates a new VMImageAgeCollector that generates metrics
+// NewVMAgeCollector creates a new VMAgeCollector that generates metrics
 // based on the buildDate and vmImageName.
-func NewVMImageAgeCollector(exportInterval time.Duration, buildDate, vmImageName string, consumer consumer.MetricsConsumer, logger *zap.Logger) *VMImageAgeCollector {
+func NewVMAgeCollector(exportInterval time.Duration, buildDate, vmImageName string, consumer consumer.MetricsConsumer, logger *zap.Logger) *VMAgeCollector {
 	if exportInterval <= 0 {
 		exportInterval = defaultExportInterval
 	}
 
-	collector := &VMImageAgeCollector{
+	collector := &VMAgeCollector{
 		consumer:       consumer,
 		startTime:      time.Now(),
 		buildDate:      buildDate,
@@ -57,7 +56,7 @@ func NewVMImageAgeCollector(exportInterval time.Duration, buildDate, vmImageName
 	return collector
 }
 
-func (collector *VMImageAgeCollector) parseBuildDate() {
+func (collector *VMAgeCollector) parseBuildDate() {
 	var err error
 	collector.parsedBuildDate, err = time.Parse(time.RFC3339, collector.buildDate)
 	collector.buildDateError = err != nil
@@ -73,7 +72,7 @@ func calculateImageAge(buildDate time.Time, now time.Time) (float64, error) {
 }
 
 // StartCollection starts a go routine with a ticker that periodically generates and exports the metrics.
-func (collector *VMImageAgeCollector) StartCollection() {
+func (collector *VMAgeCollector) StartCollection() {
 	collector.setupCollection()
 
 	go func() {
@@ -89,17 +88,17 @@ func (collector *VMImageAgeCollector) StartCollection() {
 	}()
 }
 
-func (collector *VMImageAgeCollector) setupCollection() {
+func (collector *VMAgeCollector) setupCollection() {
 	collector.parseBuildDate()
 	collector.labelValues = []*metricspb.LabelValue{metricgenerator.MakeLabelValue(collector.vmImageName)}
 }
 
 // StopCollection stops the generation and export of the metrics.
-func (collector *VMImageAgeCollector) StopCollection() {
+func (collector *VMAgeCollector) StopCollection() {
 	close(collector.done)
 }
 
-func (collector *VMImageAgeCollector) makeErrorMetrics() *metricspb.Metric {
+func (collector *VMAgeCollector) makeErrorMetrics() *metricspb.Metric {
 	timeseries := metricgenerator.MakeInt64TimeSeries(1, collector.startTime, time.Now(), collector.labelValues)
 	return &metricspb.Metric{
 		MetricDescriptor: vmImageErrorMetric,
@@ -108,7 +107,7 @@ func (collector *VMImageAgeCollector) makeErrorMetrics() *metricspb.Metric {
 
 }
 
-func (collector *VMImageAgeCollector) scrapeAndExport() {
+func (collector *VMAgeCollector) scrapeAndExport() {
 	metrics := make([]*metricspb.Metric, 0, 1)
 
 	if collector.buildDateError {

--- a/opentelemetry_collector/receiver/vmagereceiver/vm_image_age_collector_test.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/vm_image_age_collector_test.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	"context"
@@ -40,7 +40,7 @@ func TestCalculateImageAgeWith0Age(t *testing.T) {
 }
 
 func TestParseBuildDate(t *testing.T) {
-	collector := NewVMImageAgeCollector(0, "2006-01-02T15:04:05+00:00", "test_image_name", nil, nil)
+	collector := NewVMAgeCollector(0, "2006-01-02T15:04:05+00:00", "test_image_name", nil, nil)
 	collector.parseBuildDate()
 	assert.False(t, collector.buildDateError)
 	diff := collector.parsedBuildDate.Sub(time.Date(2006, time.January, 2, 15, 4, 5, 0, time.FixedZone("", 0)))
@@ -48,7 +48,7 @@ func TestParseBuildDate(t *testing.T) {
 }
 
 func TestParseBuildDateError(t *testing.T) {
-	collector := NewVMImageAgeCollector(0, "misformated_date", "test_image_name", nil, nil)
+	collector := NewVMAgeCollector(0, "misformated_date", "test_image_name", nil, nil)
 	collector.parseBuildDate()
 	assert.True(t, collector.buildDateError)
 }
@@ -72,7 +72,7 @@ func (consumer fakeConsumer) ConsumeMetrics(ctx context.Context, metrics pdata.M
 
 func TestScrapeAndExport(t *testing.T) {
 	consumer := fakeConsumer{storage: &metricsStore{}}
-	collector := NewVMImageAgeCollector(0, "2006-01-02T15:04:05+00:00", "test_image_name", consumer, zap.NewNop())
+	collector := NewVMAgeCollector(0, "2006-01-02T15:04:05+00:00", "test_image_name", consumer, zap.NewNop())
 	collector.setupCollection()
 	collector.scrapeAndExport()
 
@@ -107,7 +107,7 @@ func TestScrapeAndExport(t *testing.T) {
 
 func TestScrapeAndExportWithError(t *testing.T) {
 	consumer := fakeConsumer{storage: &metricsStore{}}
-	collector := NewVMImageAgeCollector(0, "", "test_image_name", consumer, zap.NewNop())
+	collector := NewVMAgeCollector(0, "", "test_image_name", consumer, zap.NewNop())
 	collector.setupCollection()
 	collector.scrapeAndExport()
 

--- a/opentelemetry_collector/receiver/vmagereceiver/vm_image_age_constants.go
+++ b/opentelemetry_collector/receiver/vmagereceiver/vm_image_age_constants.go
@@ -1,4 +1,4 @@
-package vmimageagereceiver
+package vmagereceiver
 
 import (
 	metricspb "github.com/census-instrumentation/opencensus-proto/gen-go/metrics/v1"

--- a/opentelemetry_collector/receiver/vmimageagereceiver/doc.go
+++ b/opentelemetry_collector/receiver/vmimageagereceiver/doc.go
@@ -1,4 +1,0 @@
-// Package vmimageagereceiver generates and periodically emits metrics based on
-// the VM image age and name in the config file. It is a metric receiver
-// designed to work with OpenTelemetry Collector.
-package vmimageagereceiver


### PR DESCRIPTION
Preparation for adding more VM age related metrics.